### PR TITLE
modifié fichier imgmgr.php pour ajouter un contenu dans alt et une ba…

### DIFF
--- a/admin/imgmgr.php
+++ b/admin/imgmgr.php
@@ -81,7 +81,10 @@ if ($imageFiles){
 	$thumbHeight = getFromConfig('thumbheight');
 	foreach ($imageFiles as $imageFile){
 		$url = substr(realpath($imageFile),strlen($_SERVER['DOCUMENT_ROOT']));
-		print '<img src="'.getResized($imageFile,$thumbWidth,$thumbHeight).'" onclick="javascript:c=parent.document.getElementById(\'content\');c.value+=\'![texte]('.$url.')\';c.focus();">';
+	//on prend qu'une partie de $url pour le nom de l'image -> attribul alt
+$name1 = explode("/",$url);
+$name2 = explode(".",$name1[5]);
+	print '<img src="'.getResized($imageFile,$thumbWidth,$thumbHeight).'" onclick="javascript:c=parent.document.getElementById(\'content\');c.value+=\'[!['.$name2[0].']('.$url.')]('.$url.')\';c.focus();">';
 		print '<button onclick="javascript:c=parent.document.getElementById(\'titlepic\');c.value=\''.$url.'\';">Utiliser comme image de titre</button>';
 	}
 }


### PR DESCRIPTION
Bonjour Stéphane
bonne année
je me suis permis de faire une petite modification sur le fichier imgmgr.php qui peut être utile:
Pour l'image qui apparaît dans l'article, j'ai ajouté du contenu à l'attribut alt, donc le nom du fichier que jai extrait à l'aide de la fonction explode()
et j'ai aussi ajouté une autre variable $url dans le but d'encadrer l'image par des balises <a> et </a> pour des liens hypertextes.
Je voulais ajouter une lightbox sur les images donc j'avais besoin des balises <a> (j'ai ajouté un attribut class à l'aide de javascript)et pour l'accessibilité, je trouve bien d'avoir du contenu dans l'attribut alt
Voilà si jamais ça vous intéresse
à bientôt
Cyril
